### PR TITLE
Emoji-onlyノートのx3拡大判定を厳密化

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "misskey",
-	"version": "2025.10.2-azk.1",
+	"version": "2025.10.2-azk.2",
 	"codename": "nasubi",
 	"repository": {
 		"type": "git",

--- a/packages/frontend/src/components/MkNote.vue
+++ b/packages/frontend/src/components/MkNote.vue
@@ -64,17 +64,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 					<div :class="$style.text">
 						<span v-if="appearNote.isHidden" style="opacity: 0.5">({{ i18n.ts.private }})</span>
 						<MkA v-if="appearNote.replyId" :class="$style.replyIcon" :to="`/notes/${appearNote.replyId}`"><i class="ti ti-arrow-back-up"></i></MkA>
-						<Mfm
-							v-if="appearNote.text"
-							:parsedNodes="parsed"
-							:text="appearNote.text"
-							:author="appearNote.user"
-							:nyaize="'respect'"
-							:emojiUrls="appearNote.emojis"
-							:enableEmojiMenu="true"
-							:enableEmojiMenuReaction="true"
-							class="_selectable"
-						/>
+					<Mfm
+						v-if="appearNote.text"
+						:parsedNodes="parsed"
+						:text="appearNote.text"
+						:author="appearNote.user"
+						:nyaize="'respect'"
+						:emojiUrls="appearNote.emojis"
+						:enableEmojiMenu="true"
+						:enableEmojiMenuReaction="true"
+						:isNote="true"
+						class="_selectable"
+					/>
 						<div v-if="translating || translation" :class="$style.translation">
 							<MkLoading v-if="translating" mini/>
 							<div v-else-if="translation">

--- a/packages/frontend/src/components/MkNoteDetailed.vue
+++ b/packages/frontend/src/components/MkNoteDetailed.vue
@@ -87,17 +87,18 @@ SPDX-License-Identifier: AGPL-3.0-only
 			<div v-show="appearNote.cw == null || showContent">
 				<span v-if="appearNote.isHidden" style="opacity: 0.5">({{ i18n.ts.private }})</span>
 				<MkA v-if="appearNote.replyId" :class="$style.noteReplyTarget" :to="`/notes/${appearNote.replyId}`"><i class="ti ti-arrow-back-up"></i></MkA>
-				<Mfm
-					v-if="appearNote.text"
-					:parsedNodes="parsed"
-					:text="appearNote.text"
-					:author="appearNote.user"
-					:nyaize="'respect'"
-					:emojiUrls="appearNote.emojis"
-					:enableEmojiMenu="true"
-					:enableEmojiMenuReaction="true"
-					class="_selectable"
-				/>
+					<Mfm
+						v-if="appearNote.text"
+						:parsedNodes="parsed"
+						:text="appearNote.text"
+						:author="appearNote.user"
+						:nyaize="'respect'"
+						:emojiUrls="appearNote.emojis"
+						:enableEmojiMenu="true"
+						:enableEmojiMenuReaction="true"
+						:isNote="true"
+						class="_selectable"
+					/>
 				<a v-if="appearNote.renote != null" :class="$style.rn">RN:</a>
 				<div v-if="translating || translation" :class="$style.translation">
 					<MkLoading v-if="translating" mini/>

--- a/packages/frontend/src/components/global/MkMfm.ts
+++ b/packages/frontend/src/components/global/MkMfm.ts
@@ -63,6 +63,7 @@ export default function (props: MfmProps, { emit }: { emit: SetupContext<MfmEven
 	//provide('linkNavigationBehavior', props.linkNavigationBehavior);
 
 	const isNote = props.isNote ?? true;
+	const isNoteStrict = props.isNote ?? false; // note なのに isNote がついていないところが散見されるため、厳密に評価する用
 	const shouldNyaize = props.nyaize ? props.nyaize === 'respect' ? props.author?.isCat : false : false;
 
 	// eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -427,7 +428,7 @@ export default function (props: MfmProps, { emit }: { emit: SetupContext<MfmEven
 			case 'emojiCode': {
 				if (props.author?.host == null) {
 					// 絵文字 only かつ、絵文字5個以下のときは拡大
-					if (isNote && isEmojiOnlyNote(rootAst) && rootAst.filter(n => n.type === 'emojiCode' || n.type === 'unicodeEmoji').length <= 5) {
+					if (isNoteStrict && isEmojiOnlyNote(rootAst) && rootAst.filter(n => n.type === 'emojiCode' || n.type === 'unicodeEmoji').length <= 5) {
 						return [h('span', {
 							class: prefer.s.advancedMfm ? 'mfm-x3' : '',
 						}, [h(MkCustomEmoji, {
@@ -457,7 +458,7 @@ export default function (props: MfmProps, { emit }: { emit: SetupContext<MfmEven
 					if (props.emojiUrls && (props.emojiUrls[token.props.name] == null)) {
 						return [h('span', `:${token.props.name}:`)];
 					} else {
-						if (isNote && isEmojiOnlyNote(rootAst) && rootAst.filter(n => n.type === 'emojiCode' || n.type === 'unicodeEmoji').length <= 5) {
+						if (isNoteStrict && isEmojiOnlyNote(rootAst) && rootAst.filter(n => n.type === 'emojiCode' || n.type === 'unicodeEmoji').length <= 5) {
 							return [h('span', {
 								class: prefer.s.advancedMfm ? 'mfm-x3' : '',
 							}, [h(MkCustomEmoji, {
@@ -487,7 +488,7 @@ export default function (props: MfmProps, { emit }: { emit: SetupContext<MfmEven
 			}
 
 			case 'unicodeEmoji': {
-				if (isNote && isEmojiOnlyNote(rootAst) && rootAst.filter(n => n.type === 'emojiCode' || n.type === 'unicodeEmoji').length <= 5) {
+				if (isNoteStrict && isEmojiOnlyNote(rootAst) && rootAst.filter(n => n.type === 'emojiCode' || n.type === 'unicodeEmoji').length <= 5) {
 					return [h('span', {
 						class: prefer.s.advancedMfm ? 'mfm-x3' : '',
 					}, [h(MkEmoji, {

--- a/packages/frontend/src/components/global/MkUserName.vue
+++ b/packages/frontend/src/components/global/MkUserName.vue
@@ -4,7 +4,7 @@ SPDX-License-Identifier: AGPL-3.0-only
 -->
 
 <template>
-<Mfm :text="user.name ?? user.username" :author="user" :plain="true" :nowrap="nowrap" :emojiUrls="user.emojis" :isNote="false"/>
+<Mfm :text="user.name ?? user.username" :author="user" :plain="true" :nowrap="nowrap" :emojiUrls="user.emojis"/>
 </template>
 
 <script lang="ts" setup>

--- a/packages/misskey-js/package.json
+++ b/packages/misskey-js/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "misskey-js",
-	"version": "2025.10.2-azk.1",
+	"version": "2025.10.2-azk.2",
 	"description": "Misskey SDK for JavaScript",
 	"license": "MIT",
 	"main": "./built/index.js",


### PR DESCRIPTION
## What
- MkMfm に `isNoteStrict` を追加し、絵文字のみのノート拡大を `isNote` 明示時に限定
- MkUserName から `:isNote="false"` を削除して新しい判定ロジックに追従
- ルートおよび misskey-js のバージョンを `2025.10.2-azk.2` に更新

## Why
- ノート以外の表示で x3 拡大が発生するのを防ぎつつ、ノート側で明示的にフラグを付ける運用へ移行するため

## Additional info (optional)
- テスト未実施

## Checklist
- [ ] Read the contribution guide
- [ ] Test working in a local environment
- [ ] (If needed) Update CHANGELOG.md
- [ ] (If possible) Add tests