### PR TITLE
Allow viewing private notes on global timeline

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "misskey",
-	"version": "2025.10.2-azk.2",
+	"version": "2025.10.2-azk.3",
 	"codename": "nasubi",
 	"repository": {
 		"type": "git",

--- a/packages/backend/src/server/api/endpoints/notes/global-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/global-timeline.ts
@@ -70,7 +70,6 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 			//#region Construct query
 			const query = this.queryService.makePaginationQuery(this.notesRepository.createQueryBuilder('note'),
 				ps.sinceId, ps.untilId, ps.sinceDate, ps.untilDate)
-				.andWhere('note.visibility = \'public\'')
 				.andWhere('note.channelId IS NULL')
 				.innerJoinAndSelect('note.user', 'user')
 				.leftJoinAndSelect('note.reply', 'reply')
@@ -78,8 +77,14 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				.leftJoinAndSelect('reply.user', 'replyUser')
 				.leftJoinAndSelect('renote.user', 'renoteUser');
 
+			if (me) {
+				this.queryService.generateVisibilityQuery(query, me);
+				this.queryService.generateMutedUserRenotesQueryForNotes(query, me);
+			} else {
+				query.andWhere('note.visibility = \'public\'');
+			}
+
 			this.queryService.generateBaseNoteFilteringQuery(query, me);
-			if (me) this.queryService.generateMutedUserRenotesQueryForNotes(query, me);
 
 			if (ps.withFiles) {
 				query.andWhere('note.fileIds != \'{}\'');

--- a/packages/backend/src/server/api/endpoints/notes/global-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/global-timeline.ts
@@ -80,6 +80,8 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				if (me) {
 					this.queryService.generateVisibilityQuery(query, me);
 					this.queryService.generateMutedUserRenotesQueryForNotes(query, me);
+					// visibility の共通ルールで public/followers/specified を絞ったあと、
+					// home (未収載) だけは「自分自身 or フォローしている相手」かを追加でチェックする
 
 					const followExists = query.subQuery()
 						.select('1')

--- a/packages/backend/src/server/api/endpoints/notes/global-timeline.ts
+++ b/packages/backend/src/server/api/endpoints/notes/global-timeline.ts
@@ -77,12 +77,24 @@ export default class extends Endpoint<typeof meta, typeof paramDef> { // eslint-
 				.leftJoinAndSelect('reply.user', 'replyUser')
 				.leftJoinAndSelect('renote.user', 'renoteUser');
 
-			if (me) {
-				this.queryService.generateVisibilityQuery(query, me);
-				this.queryService.generateMutedUserRenotesQueryForNotes(query, me);
-			} else {
-				query.andWhere('note.visibility = \'public\'');
-			}
+				if (me) {
+					this.queryService.generateVisibilityQuery(query, me);
+					this.queryService.generateMutedUserRenotesQueryForNotes(query, me);
+
+					const followExists = query.subQuery()
+						.select('1')
+						.from('following', 'following')
+						.where('following.followeeId = note.userId')
+						.andWhere('following.followerId = :meId');
+
+					query.andWhere(new Brackets(qb => {
+						qb.where('note.visibility != \'home\'')
+							.orWhere('note.userId = :meId')
+							.orWhere(`EXISTS (${ followExists.getQuery() })`);
+					})).setParameter('meId', me.id);
+				} else {
+					query.andWhere('note.visibility = \'public\'');
+				}
 
 			this.queryService.generateBaseNoteFilteringQuery(query, me);
 

--- a/packages/backend/src/server/api/stream/channels/global-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/global-timeline.ts
@@ -22,7 +22,8 @@ class GlobalTimelineChannel extends Channel {
 
 	private canSee(note: Packed<'Note'>): boolean {
 		// Global TL の API と同じ visibility ルールをストリーミングにも適用し、
-		// 非公開ノートが権限のない接続に流出したり、逆に閲覧権のあるノートが欠落したりしないようにする
+		// 非公開ノートが権限のない接続に流出したり、逆に閲覧権のあるノートが欠落したりしないようにする。
+		// まず public/followers/specified の共通ルールでフィルタしたあと、最後に home だけ追加条件（自分自身 or フォロー済み）を課している。
 		if (note.visibility === 'public') return true;
 		if (note.visibility === 'home') {
 			if (!this.user) return false;

--- a/packages/backend/src/server/api/stream/channels/global-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/global-timeline.ts
@@ -23,7 +23,11 @@ class GlobalTimelineChannel extends Channel {
 	private canSee(note: Packed<'Note'>): boolean {
 		// Global TL の API と同じ visibility ルールをストリーミングにも適用し、
 		// 非公開ノートが権限のない接続に流出したり、逆に閲覧権のあるノートが欠落したりしないようにする
-		if (note.visibility === 'public' || note.visibility === 'home') return true;
+		if (note.visibility === 'public') return true;
+		if (note.visibility === 'home') {
+			if (!this.user) return false;
+			return note.userId === this.user.id || Object.hasOwn(this.following, note.userId);
+		}
 		if (note.visibility === 'specified') {
 			if (!this.user) return false;
 			if (note.userId === this.user.id) return true;

--- a/packages/backend/src/server/api/stream/channels/global-timeline.ts
+++ b/packages/backend/src/server/api/stream/channels/global-timeline.ts
@@ -20,6 +20,25 @@ class GlobalTimelineChannel extends Channel {
 	private withRenotes: boolean;
 	private withFiles: boolean;
 
+	private canSee(note: Packed<'Note'>): boolean {
+		// Global TL の API と同じ visibility ルールをストリーミングにも適用し、
+		// 非公開ノートが権限のない接続に流出したり、逆に閲覧権のあるノートが欠落したりしないようにする
+		if (note.visibility === 'public' || note.visibility === 'home') return true;
+		if (note.visibility === 'specified') {
+			if (!this.user) return false;
+			if (note.userId === this.user.id) return true;
+			return note.visibleUserIds?.includes(this.user.id) ?? false;
+		}
+		if (note.visibility === 'followers') {
+			if (!this.user) return false;
+			if (note.userId === this.user.id) return true;
+			if (note.reply && note.reply.userId === this.user.id) return true;
+			if (note.mentions?.includes(this.user.id)) return true;
+			return Object.hasOwn(this.following, note.userId);
+		}
+		return false;
+	}
+
 	constructor(
 		private metaService: MetaService,
 		private roleService: RoleService,
@@ -48,7 +67,7 @@ class GlobalTimelineChannel extends Channel {
 	private async onNote(note: Packed<'Note'>) {
 		if (this.withFiles && (note.fileIds == null || note.fileIds.length === 0)) return;
 
-		if (note.visibility !== 'public') return;
+		if (!this.canSee(note)) return;
 		if (note.channelId != null) return;
 		if (note.user.requireSigninToViewContents && this.user == null) return;
 		if (note.renote && note.renote.user.requireSigninToViewContents && this.user == null) return;

--- a/packages/backend/test-federation/test/timeline.test.ts
+++ b/packages/backend/test-federation/test/timeline.test.ts
@@ -172,16 +172,16 @@ describe('Timeline', () => {
 				await postAndCheckReception(globalTimeline, true);
 			});
 
-			test('Don\'t receive remote followee\'s home-only Note', async () => {
-				await postAndCheckReception(globalTimeline, false, { visibility: 'home' });
+			test('Receive remote followee\'s home-only Note', async () => {
+				await postAndCheckReception(globalTimeline, true, { visibility: 'home' });
 			});
 
-			test('Don\'t receive remote followee\'s followers-only Note', async () => {
-				await postAndCheckReception(globalTimeline, false, { visibility: 'followers' });
+			test('Receive remote followee\'s followers-only Note', async () => {
+				await postAndCheckReception(globalTimeline, true, { visibility: 'followers' });
 			});
 
-			test('Don\'t receive remote followee\'s visible specified-only Note', async () => {
-				await postAndCheckReception(globalTimeline, false, { visibility: 'specified', visibleUserIds: [bobInA.id] });
+			test('Receive remote followee\'s visible specified-only Note', async () => {
+				await postAndCheckReception(globalTimeline, true, { visibility: 'specified', visibleUserIds: [bobInA.id] });
 			});
 		});
 	});

--- a/packages/backend/test/e2e/streaming.ts
+++ b/packages/backend/test/e2e/streaming.ts
@@ -572,6 +572,16 @@ describe('Streaming', () => {
 				assert.strictEqual(fired, true);
 			});
 
+			test('フォローしていないユーザーのホーム投稿は流れない', async () => {
+				const fired = await waitFire(
+					erin, 'globalTimeline',
+					() => api('notes/create', { text: 'foo', visibility: 'home' }, kyoko),
+					msg => msg.type === 'note' && msg.body.userId === kyoko.id,
+				);
+
+				assert.strictEqual(fired, false);
+			});
+
 			test('フォローしているユーザーの visibility: followers な投稿が流れる', async () => {
 				const fired = await waitFire(
 					ayano, 'globalTimeline',	// ayano:Global

--- a/packages/backend/test/e2e/streaming.ts
+++ b/packages/backend/test/e2e/streaming.ts
@@ -562,11 +562,51 @@ describe('Streaming', () => {
 			});
 			*/
 
-			test('ホーム投稿は流れない', async () => {
+			test('フォローしているユーザーのホーム投稿が流れる', async () => {
 				const fired = await waitFire(
 					ayano, 'globalTimeline',	// ayano:Global
 					() => api('notes/create', { text: 'foo', visibility: 'home' }, kyoko),	// kyoko posts
 					msg => msg.type === 'note' && msg.body.userId === kyoko.id,	// wait kyoko
+				);
+
+				assert.strictEqual(fired, true);
+			});
+
+			test('フォローしているユーザーの visibility: followers な投稿が流れる', async () => {
+				const fired = await waitFire(
+					ayano, 'globalTimeline',	// ayano:Global
+					() => api('notes/create', { text: 'followers only', visibility: 'followers' }, kyoko),
+					msg => msg.type === 'note' && msg.body.userId === kyoko.id && msg.body.text === 'followers only',
+				);
+
+				assert.strictEqual(fired, true);
+			});
+
+			test('フォローしていないユーザーの visibility: followers な投稿は流れない', async () => {
+				const fired = await waitFire(
+					ayano, 'globalTimeline',	// ayano:Global
+					() => api('notes/create', { text: 'followers only', visibility: 'followers' }, chitose),
+					msg => msg.type === 'note' && msg.body.userId === chitose.id,
+				);
+
+				assert.strictEqual(fired, false);
+			});
+
+			test('自分宛ての visibility: specified な投稿が流れる', async () => {
+				const fired = await waitFire(
+					ayano, 'globalTimeline',
+					() => api('notes/create', { text: 'direct', visibility: 'specified', visibleUserIds: [ayano.id] }, kyoko),
+					msg => msg.type === 'note' && msg.body.userId === kyoko.id && msg.body.text === 'direct',
+				);
+
+				assert.strictEqual(fired, true);
+			});
+
+			test('自分宛てでない visibility: specified な投稿は流れない', async () => {
+				const fired = await waitFire(
+					ayano, 'globalTimeline',
+					() => api('notes/create', { text: 'nope', visibility: 'specified', visibleUserIds: [erin.id] }, kyoko),
+					msg => msg.type === 'note' && msg.body.userId === kyoko.id && msg.body.text === 'nope',
 				);
 
 				assert.strictEqual(fired, false);

--- a/packages/backend/test/e2e/timelines.ts
+++ b/packages/backend/test/e2e/timelines.ts
@@ -1939,6 +1939,49 @@ describe('Timelines', () => {
 			});
 		});
 
+		describe('Global TL', () => {
+			test('フォローしているユーザーの visibility: followers なノートが含まれる', async () => {
+				const [alice, bob] = await Promise.all([signup(), signup()]);
+
+				await api('following/create', { userId: bob.id }, alice);
+				await setTimeout(250);
+				const bobNote = await post(bob, { text: 'hi', visibility: 'followers' });
+
+				await waitForPushToTl();
+
+				const res = await api('notes/global-timeline', { limit: 100 }, alice);
+
+				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				assert.strictEqual(res.body.find(note => note.id === bobNote.id)?.text, 'hi');
+			});
+
+			test('自分宛ての指定公開ノートが含まれる', async () => {
+				const [alice, bob] = await Promise.all([signup(), signup()]);
+
+				const bobNote = await post(bob, { text: 'secret', visibility: 'specified', visibleUserIds: [alice.id] });
+
+				await waitForPushToTl();
+
+				const res = await api('notes/global-timeline', { limit: 100 }, alice);
+
+				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+				assert.strictEqual(res.body.find(note => note.id === bobNote.id)?.text, 'secret');
+			});
+
+			test('未ログイン時はフォロー限定ノートが含まれない', async () => {
+				const [alice] = await Promise.all([signup()]);
+
+				await post(alice, { text: 'hidden', visibility: 'followers' });
+
+				await waitForPushToTl();
+
+				const res = await api('notes/global-timeline', { limit: 100 });
+
+				assert.strictEqual(res.body.some(note => note.text === 'hidden'), false);
+				assert.strictEqual(res.body.length <= 100, true);
+			});
+		});
+
 		// TODO: リノートミュート済みユーザーのテスト
 		// TODO: ページネーションのテスト
 	});

--- a/packages/backend/test/e2e/timelines.ts
+++ b/packages/backend/test/e2e/timelines.ts
@@ -1940,6 +1940,32 @@ describe('Timelines', () => {
 		});
 
 		describe('Global TL', () => {
+			test('フォローしているユーザーの visibility: home なノートが含まれる', async () => {
+				const [alice, bob] = await Promise.all([signup(), signup()]);
+
+				await api('following/create', { userId: bob.id }, alice);
+				await setTimeout(250);
+				const bobNote = await post(bob, { text: 'hi', visibility: 'home' });
+
+				await waitForPushToTl();
+
+				const res = await api('notes/global-timeline', { limit: 100 }, alice);
+
+				assert.strictEqual(res.body.some(note => note.id === bobNote.id), true);
+			});
+
+			test('フォローしていないユーザーの visibility: home なノートが含まれない', async () => {
+				const [alice, bob] = await Promise.all([signup(), signup()]);
+
+				const bobNote = await post(bob, { text: 'hi', visibility: 'home' });
+
+				await waitForPushToTl();
+
+				const res = await api('notes/global-timeline', { limit: 100 }, alice);
+
+				assert.strictEqual(res.body.some(note => note.id === bobNote.id), false);
+			});
+
 			test('フォローしているユーザーの visibility: followers なノートが含まれる', async () => {
 				const [alice, bob] = await Promise.all([signup(), signup()]);
 

--- a/packages/misskey-js/package.json
+++ b/packages/misskey-js/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "misskey-js",
-	"version": "2025.10.2-azk.2",
+	"version": "2025.10.2-azk.3",
 	"description": "Misskey SDK for JavaScript",
 	"license": "MIT",
 	"main": "./built/index.js",


### PR DESCRIPTION
## 概要
- グローバルTL APIでログイン中ユーザーに対してフォロワー限定・指定公開ノートも返すよう visibility 判定を導入
- ストリーミングの globalTimeline チャンネルでも同じ判定を行い、RESTと可視範囲を揃える
- 上記仕様を担保する e2e / federated テストを追加