### PR TITLE
Request-Id ヘッダのログ出力対応

### DIFF
--- a/packages/backend/src/logger.ts
+++ b/packages/backend/src/logger.ts
@@ -9,6 +9,7 @@ import { default as convertColor } from 'color-convert';
 import { format as dateFormat } from 'date-fns';
 import { bindThis } from '@/decorators.js';
 import { envOption } from './env.js';
+import { getCurrentTraceId } from '@/tracing/TraceContext.js';
 import type { KEYWORD } from 'color-convert/conversions.js';
 
 type Context = {
@@ -56,6 +57,7 @@ export default class Logger {
 			level === 'info' ? chalk.blue('INFO') :
 			null;
 		const contexts = [this.context].concat(subContexts).map(d => d.color ? chalk.rgb(...convertColor.keyword.rgb(d.color))(d.name) : chalk.white(d.name));
+		const traceId = getCurrentTraceId();
 		const m =
 			level === 'error' ? chalk.red(message) :
 			level === 'warning' ? chalk.yellow(message) :
@@ -65,6 +67,9 @@ export default class Logger {
 			null;
 
 		let log = `${l} ${worker}\t[${contexts.join(' ')}]\t${m}`;
+		if (traceId) {
+			log += chalk.gray(` TraceId: ${traceId}`);
+		}
 		if (envOption.withLogTime) log = chalk.gray(time) + ' ' + log;
 
 		const args: unknown[] = [important ? chalk.bold(log) : log];

--- a/packages/backend/src/server/ServerService.ts
+++ b/packages/backend/src/server/ServerService.ts
@@ -31,6 +31,7 @@ import { HealthServerService } from './HealthServerService.js';
 import { ClientServerService } from './web/ClientServerService.js';
 import { OpenApiServerService } from './api/openapi/OpenApiServerService.js';
 import { OAuth2ProviderService } from './oauth/OAuth2ProviderService.js';
+import { runWithTraceId } from '@/tracing/TraceContext.js';
 
 const _dirname = fileURLToPath(new URL('.', import.meta.url));
 
@@ -79,6 +80,19 @@ export class ServerService implements OnApplicationShutdown {
 			logger: false,
 		});
 		this.#fastify = fastify;
+
+		fastify.addHook('onRequest', (request, reply, done) => {
+			const headerValue = request.headers['request-id'];
+			const rawTraceId = Array.isArray(headerValue) ? headerValue[0] : headerValue;
+			const traceId = typeof rawTraceId === 'string' ? rawTraceId.trim() : undefined;
+
+			if (!traceId) {
+				done();
+				return;
+			}
+
+			runWithTraceId(traceId, done);
+		});
 
 		// HSTS
 		// 6months (15552000sec)

--- a/packages/backend/src/tracing/TraceContext.ts
+++ b/packages/backend/src/tracing/TraceContext.ts
@@ -1,0 +1,21 @@
+/*
+ * SPDX-FileCopyrightText: syuilo and misskey-project
+ * SPDX-FileCopyrightText: 2025 azuki774
+ * SPDX-License-Identifier: AGPL-3.0-only
+ */
+
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+type TraceStore = {
+	traceId?: string;
+};
+
+const traceContext = new AsyncLocalStorage<TraceStore>();
+
+export function runWithTraceId<T>(traceId: string, callback: () => T): T {
+	return traceContext.run({ traceId }, callback);
+}
+
+export function getCurrentTraceId(): string | undefined {
+	return traceContext.getStore()?.traceId;
+}


### PR DESCRIPTION
## 概要
- Fastify の onRequest フックで Request-Id ヘッダを取得し、トレースコンテキストに渡すようにしました
- AsyncLocalStorage を使った TraceContext を新設し、Logger で TraceId を自動表示するようにしました
- ヘッダが存在しない場合は従来通りのログ出力です