### PR TITLE
[codex] Bump version to 2026.5.1-azk.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "misskey",
-	"version": "2026.5.1-azk.1",
+	"version": "2026.5.1-azk.3",
 	"codename": "nasubi",
 	"repository": {
 		"type": "git",

--- a/packages/misskey-js/package.json
+++ b/packages/misskey-js/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "misskey-js",
-	"version": "2026.5.1-azk.1",
+	"version": "2026.5.1-azk.3",
 	"description": "Misskey SDK for JavaScript",
 	"license": "MIT",
 	"main": "./built/index.js",


### PR DESCRIPTION
## Summary

- Update the root package version to `2026.5.1-azk.3`.
- Update the `misskey-js` package version to `2026.5.1-azk.3`.

## Notes

- No tag was created or pushed. Tag handling is left to humans as requested.

## Validation

- `git diff --check`
- Confirmed no remaining `2026.5.1-azk.1` / `2025.5.1-azk.2` version strings in the searched package/version files.