### PR TITLE
Fix nyokiru MFM suffix handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "misskey",
-	"version": "2026.5.1-azk.3",
+	"version": "2026.5.1-azk.4",
 	"codename": "nasubi",
 	"repository": {
 		"type": "git",

--- a/packages/frontend/src/utility/nyokiru.ts
+++ b/packages/frontend/src/utility/nyokiru.ts
@@ -3,6 +3,10 @@
  * SPDX-License-Identifier: AGPL-3.0-only
  */
 
+import * as mfm from 'mfm-js';
+
+const nyokiruSuffixes = ['', ' ', '\n'] as const;
+
 function incrementAsciiInteger(digits: string): string {
 	let carry = 1;
 	let result = '';
@@ -28,11 +32,48 @@ function asciiDigitsToFullWidth(digits: string): string {
 	return digits.replace(/[0-9]/g, digit => String.fromCharCode(digit.charCodeAt(0) + 0xFF10 - 0x30));
 }
 
+function isSameMfmNode(a: mfm.MfmNode, b: mfm.MfmNode): boolean {
+	return JSON.stringify(a) === JSON.stringify(b);
+}
+
+function keepsParsedPrefix(base: mfm.MfmNode[], candidate: mfm.MfmNode[]): boolean {
+	if (base.length === 0 || candidate.length < base.length) return false;
+
+	for (let i = 0; i < base.length - 1; i++) {
+		if (!isSameMfmNode(base[i], candidate[i])) return false;
+	}
+
+	const baseLast = base[base.length - 1];
+	const candidateLast = candidate[base.length - 1];
+	if (isSameMfmNode(baseLast, candidateLast)) return true;
+
+	return baseLast.type === 'text' &&
+		candidateLast.type === 'text' &&
+		candidateLast.props.text.startsWith(baseLast.props.text);
+}
+
+function getNyokiruSuffix(text: string): typeof nyokiruSuffixes[number] {
+	const base = mfm.parse(text);
+
+	for (const suffix of nyokiruSuffixes) {
+		if (keepsParsedPrefix(base, mfm.parse(`${text}${suffix}2`))) {
+			return suffix;
+		}
+	}
+
+	return '';
+}
+
+function shouldIncrementTrailingNumber(text: string, trailingNumber: string): boolean {
+	const nodes = mfm.parse(text);
+	const lastNode = nodes.at(-1);
+	return lastNode?.type === 'text' && lastNode.props.text.endsWith(trailingNumber);
+}
+
 export function createNyokiruText(text: string): string {
 	const match = /^(.*?)([0-9]+|[０-９]+)$/s.exec(text);
-	if (!match) {
-		return `${text}2`;
-	}
+	if (!match) return `${text}${getNyokiruSuffix(text)}2`;
+	if (!shouldIncrementTrailingNumber(text, match[2])) return `${text}${getNyokiruSuffix(text)}2`;
 
 	const trailingNumber = match[2];
 	const incremented = incrementAsciiInteger(fullWidthDigitsToAscii(trailingNumber));

--- a/packages/frontend/test/nyokiru.test.ts
+++ b/packages/frontend/test/nyokiru.test.ts
@@ -47,6 +47,12 @@ describe('createNyokiruText', () => {
 		expect(createNyokiruText('abc123def')).toBe('abc123def2');
 	});
 
+	test('handles short punctuation-only text', () => {
+		expect(createNyokiruText('.')).toBe('.2');
+		expect(createNyokiruText(',')).toBe(',2');
+		expect(createNyokiruText('!')).toBe('!2');
+	});
+
 	test('adds 2 with a space after a custom emoji', () => {
 		expect(createNyokiruText(':hoge:')).toBe(':hoge: 2');
 	});

--- a/packages/frontend/test/nyokiru.test.ts
+++ b/packages/frontend/test/nyokiru.test.ts
@@ -47,6 +47,66 @@ describe('createNyokiruText', () => {
 		expect(createNyokiruText('abc123def')).toBe('abc123def2');
 	});
 
+	test('adds 2 with a space after a custom emoji', () => {
+		expect(createNyokiruText(':hoge:')).toBe(':hoge: 2');
+	});
+
+	test('adds 2 with a space after a hyphenated custom emoji', () => {
+		expect(createNyokiruText(':hoge-foo:')).toBe(':hoge-foo: 2');
+	});
+
+	test('adds 2 with a space after text ending with a custom emoji', () => {
+		expect(createNyokiruText('abc :hoge:')).toBe('abc :hoge: 2');
+	});
+
+	test('increments a number after a custom emoji when separated by a space', () => {
+		expect(createNyokiruText(':hoge: 2')).toBe(':hoge: 3');
+	});
+
+	test('adds 2 with a space after a URL', () => {
+		expect(createNyokiruText('https://example.com')).toBe('https://example.com 2');
+	});
+
+	test('adds 2 with a space after an http URL', () => {
+		expect(createNyokiruText('http://example.com')).toBe('http://example.com 2');
+	});
+
+	test('adds 2 with a space after a URL ending with a number', () => {
+		expect(createNyokiruText('https://example.com/path/1')).toBe('https://example.com/path/1 2');
+	});
+
+	test('adds 2 with a space after a mention', () => {
+		expect(createNyokiruText('@alice')).toBe('@alice 2');
+	});
+
+	test('adds 2 with a space after a remote mention ending with a number', () => {
+		expect(createNyokiruText('@alice@example.com2')).toBe('@alice@example.com2 2');
+	});
+
+	test('adds 2 with a space after a hashtag', () => {
+		expect(createNyokiruText('#tag')).toBe('#tag 2');
+	});
+
+	test('adds 2 with a newline after a quote', () => {
+		expect(createNyokiruText('> quote')).toBe('> quote\n2');
+	});
+
+	test('adds 2 with a newline after a code block', () => {
+		expect(createNyokiruText('```\ncode\n```')).toBe('```\ncode\n```\n2');
+	});
+
+	test('adds 2 with a newline after a math block', () => {
+		expect(createNyokiruText('\\[x+1\\]')).toBe('\\[x+1\\]\n2');
+	});
+
+	test('adds 2 with a newline after a search syntax', () => {
+		expect(createNyokiruText('検索 [search]')).toBe('検索 [search]\n2');
+	});
+
+	test('adds 2 with a newline after a center tag', () => {
+		expect(createNyokiruText('<center>text</center>')).toBe('<center>text</center>\n2');
+	});
+
 	test('handles empty text', () => {
 		expect(createNyokiruText('')).toBe('2');
 	});

--- a/packages/misskey-js/package.json
+++ b/packages/misskey-js/package.json
@@ -1,7 +1,7 @@
 {
 	"type": "module",
 	"name": "misskey-js",
-	"version": "2026.5.1-azk.3",
+	"version": "2026.5.1-azk.4",
 	"description": "Misskey SDK for JavaScript",
 	"license": "MIT",
 	"main": "./built/index.js",


### PR DESCRIPTION
## Summary

- Update `createNyokiruText` to choose a safe suffix using `mfm-js` parsing instead of growing one-off suffix regexes.
- Preserve trailing MFM tokens when adding `2`, including custom emoji, URLs, mentions, hashtags, quotes, code blocks, math blocks, search syntax, and center tags.
- Keep the existing trailing ASCII/full-width number increment behavior when the trailing number is plain text.

## Why

Issue #20 reported that appending `2` directly after `:emoji:` breaks MFM rendering. URL suffixes have the same kind of problem, and parser checks showed several other MFM tokens can also be changed or broken by direct concatenation.

## Validation

- `./node_modules/.bin/pnpm --filter frontend exec vitest --run --globals test/nyokiru.test.ts`
- `./node_modules/.bin/pnpm --filter frontend exec eslint --quiet src/utility/nyokiru.ts`

Tags were not created.